### PR TITLE
fix: Top-level locale folder for django_app localization in settings.py

### DIFF
--- a/tools/devious/pyproject.toml
+++ b/tools/devious/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "devious"
-version = "0.3.0"
+version = "0.3.1"
 description = "Generic development cli for various application types."
 authors = ["Felix Trautwein <mail@felixtrautwein.de>"]
 readme = "readme.md"

--- a/tools/devious/src/devious/targets/django_app/config/settings.py
+++ b/tools/devious/src/devious/targets/django_app/config/settings.py
@@ -98,6 +98,8 @@ USE_I18N = True
 
 USE_TZ = True
 
+LOCALE_PATHS = [BASE_DIR / "locale"]
+
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/


### PR DESCRIPTION
- Add `BASE_DIR / "locale"` in `LOCALE_PATHS`setting for django_apps